### PR TITLE
Update to rubocop 0.49.1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,7 +13,7 @@ Rails:
 Style/DoubleNegation:
   Enabled: false
 
-Style/SpaceInsideBrackets:
+Layout/SpaceInsideBrackets:
   Enabled: false
 
 Style/Documentation:
@@ -46,10 +46,10 @@ Metrics/AbcSize:
 Metrics/MethodLength:
   Max: 15
 
-Style/IndentArray:
+Layout/IndentArray:
   EnforcedStyle: consistent
 
-Style/IndentHash:
+Layout/IndentHash:
   EnforcedStyle: consistent
   
 Style/BracesAroundHashParameters:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Base [rubocop](https://github.com/bbatsov/rubocop#inheriting-configuration-from-
 
 ## Usage
 
-Just add an inheritence line to your project's `.rubocop.yml` file. Ensure you have Rubocop `0.35.0` or later installed.
+Just add an inheritence line to your project's `.rubocop.yml` file. Ensure you have Rubocop `0.49.1` or later installed.
 
 ```yaml
 inherit_from:


### PR DESCRIPTION
A few of the cop names have changed namespaces.

Also the latest rubocop has a lot of bug fixes.