### PR TITLE
Use the two cops that have replaced SpaceInsideBrackets

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,8 +12,11 @@ Rails:
 
 Style/DoubleNegation:
   Enabled: false
+  
+Layout/SpaceInsideReferenceBrackets:
+  Enabled: false
 
-Layout/SpaceInsideBrackets:
+Layout/SpaceInsideArrayLiteralBrackets:
   Enabled: false
 
 Style/Documentation:
@@ -51,6 +54,6 @@ Layout/IndentArray:
 
 Layout/IndentHash:
   EnforcedStyle: consistent
-  
+
 Style/BracesAroundHashParameters:
   Enabled: false


### PR DESCRIPTION
This is no longer a valid cop. Has been replaced by two other ones:
https://github.com/bbatsov/rubocop/pull/5149